### PR TITLE
add option to use FQDN when looking up servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module hcloud-ip
 
 go 1.16
 
-require github.com/hetznercloud/hcloud-go v1.24.0
+require (
+	github.com/Showmax/go-fqdn v1.0.0 // indirect
+	github.com/hetznercloud/hcloud-go v1.24.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hetznercloud/hcloud-go v1.24.0 h1:/CeHDzhH3Fhm83pjxvE3xNNLbvACl0Lu1/auJ83gG5U=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/Showmax/go-fqdn"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
@@ -14,6 +15,7 @@ func main() {
 
 	apiKey := flag.String("key", "HCloud API Key", "-key xaxaxaxax")
 	floatIP := flag.String("ip", "Name of Floating IP", "-ip voip")
+	useFqdn := flag.Bool("fqdn", false, "use FQDN instead of just the hostname when looking up servers")
 	flag.Parse()
 
 	// Check for API Key
@@ -26,11 +28,16 @@ func main() {
 	}
 
 	// Get System Hostname
-	name, err := os.Hostname()
+	var name string
+	var err error
+	if *useFqdn {
+		name, err = fqdn.FqdnHostname()
+	} else {
+		name, err = os.Hostname()
+	}
 	if err != nil {
 		panic(err)
 	}
-
 	// Initialize HCloud Client
 	client := hcloud.NewClient(hcloud.WithToken(*apiKey))
 


### PR DESCRIPTION
We need the option to use the FQDN when looking up servers through the Hetzner API, so I created this little patch.
